### PR TITLE
Fix self-hosted Python tool cache for setup-python

### DIFF
--- a/.github/workflows/optimize-dispatch.yml
+++ b/.github/workflows/optimize-dispatch.yml
@@ -78,11 +78,17 @@ jobs:
     timeout-minutes: 60
     env:
       MPLBACKEND: Agg
+      RUNNER_TOOL_CACHE: ${{ github.workspace }}/.runner-tool-cache
+      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/.runner-tool-cache
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+
+      - name: Prepare local Python tool cache
+        run: |
+          mkdir -p "$RUNNER_TOOL_CACHE"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.github/workflows/optimize-scheduled.yml
+++ b/.github/workflows/optimize-scheduled.yml
@@ -24,11 +24,17 @@ jobs:
     timeout-minutes: 60
     env:
       MPLBACKEND: Agg
+      RUNNER_TOOL_CACHE: ${{ github.workspace }}/.runner-tool-cache
+      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/.runner-tool-cache
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+
+      - name: Prepare local Python tool cache
+        run: |
+          mkdir -p "$RUNNER_TOOL_CACHE"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
This routes actions/setup-python to a writable tool cache inside the job workspace for the self-hosted macOS runner, and creates that directory before setup-python runs. It fixes the permission failure where setup-python tried to create /Users/runner on the Mac mini.