### PR TITLE
Use runner Python on self-hosted macOS workflows

### DIFF
--- a/.github/workflows/optimize-dispatch.yml
+++ b/.github/workflows/optimize-dispatch.yml
@@ -78,32 +78,26 @@ jobs:
     timeout-minutes: 60
     env:
       MPLBACKEND: Agg
-      RUNNER_TOOL_CACHE: ${{ github.workspace }}/.runner-tool-cache
-      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/.runner-tool-cache
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - name: Prepare local Python tool cache
+      - name: Set up local virtual environment
         run: |
-          mkdir -p "$RUNNER_TOOL_CACHE"
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: "3.12"
+          python3 --version
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
+          .venv/bin/python -m pip install -r requirements.txt
+          .venv/bin/python -m pip install -e .
 
       - name: Run campaign
         run: >-
-          python scripts/run_campaign.py
+          .venv/bin/python scripts/run_campaign.py
           --num-trials ${{ inputs.num_trials }}
           --seed ${{ inputs.seed }}
           ${{ inputs.drift_range != '' && format('--drift-range {0}', inputs.drift_range) || '' }}
@@ -132,7 +126,7 @@ jobs:
             git rm -rf . >/dev/null 2>&1 || true
             cd ..
           fi
-          python scripts/push_state_branch.py --source-root "$PWD" --target-root "$PWD/.agent-state"
+          .venv/bin/python scripts/push_state_branch.py --source-root "$PWD" --target-root "$PWD/.agent-state"
 
       - name: Commit and push state branch
         if: inputs.push_state_branch == 'true'

--- a/.github/workflows/optimize-scheduled.yml
+++ b/.github/workflows/optimize-scheduled.yml
@@ -24,31 +24,25 @@ jobs:
     timeout-minutes: 60
     env:
       MPLBACKEND: Agg
-      RUNNER_TOOL_CACHE: ${{ github.workspace }}/.runner-tool-cache
-      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/.runner-tool-cache
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - name: Prepare local Python tool cache
+      - name: Set up local virtual environment
         run: |
-          mkdir -p "$RUNNER_TOOL_CACHE"
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: "3.12"
+          python3 --version
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
+          .venv/bin/python -m pip install -r requirements.txt
+          .venv/bin/python -m pip install -e .
 
       - name: Run bounded scheduled campaign
-        run: python scripts/run_campaign.py --num-trials 1 --seed 1701
+        run: .venv/bin/python scripts/run_campaign.py --num-trials 1 --seed 1701
 
       - name: Upload optimization artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -73,7 +67,7 @@ jobs:
             git rm -rf . >/dev/null 2>&1 || true
             cd ..
           fi
-          python scripts/push_state_branch.py --source-root "$PWD" --target-root "$PWD/.agent-state"
+          .venv/bin/python scripts/push_state_branch.py --source-root "$PWD" --target-root "$PWD/.agent-state"
           cd .agent-state
           git config user.name github-actions
           git config user.email github-actions@users.noreply.github.com


### PR DESCRIPTION
This removes actions/setup-python from the self-hosted optimization workflows and uses the runner machines existing python3 via a local .venv instead. On macOS self-hosted runners, setup-python hardcodes /Users/runner/hostedtoolcache, so overriding the cache path in workflow env does not prevent the permission failure.