### PR TITLE
Add relativistic research agent brief

### DIFF
--- a/.github/ISSUE_TEMPLATE/relativistic-research-agent.md
+++ b/.github/ISSUE_TEMPLATE/relativistic-research-agent.md
@@ -1,0 +1,39 @@
+---
+name: Relativistic Research Agent
+about: PR-first agent task for momentum-space relativistic PIC research and implementation planning
+title: "Relativistic milestone: "
+labels: []
+assignees: []
+---
+
+## Goal
+
+Move PIC_AGENTIC_WORKFLOW one bounded step closer to a formally relativistic, momentum-space 1D3V PIC workflow that can later be upstreamed into JAX-in-Cell.
+
+## Scope
+
+- Work only in this repository.
+- Do not modify JAX-in-Cell directly from here.
+- Keep changes PR-first and narrowly scoped.
+- Do not weaken any repository security or workflow restrictions.
+
+## Required Prompt
+
+Use the instructions in [agent/prompts/relativistic_research.md](/Users/rogerio/local/PIC_agentic_workflow/agent/prompts/relativistic_research.md).
+
+## Milestone For This Issue
+
+Describe one milestone only. Examples:
+
+- define benchmark cases from literature for relativistic 1D3V electrostatic PIC
+- add Maxwell-Juttner momentum-space sampling validation utilities
+- add momentum-space schema and documentation for relativistic initialization
+- add energy-conservation diagnostics and reporting for relativistic test cases
+- write the upstream migration plan for converting JAX-in-Cell from velocity to momentum state variables
+
+## Acceptance Criteria
+
+- Open a PR against `main`.
+- Include a scientific rationale in the PR body.
+- Include tests, validation artifacts, or a clearly bounded research summary.
+- End the PR with the next recommended milestone.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ The optimizer state is stored as JSON observations rather than a Python pickle. 
 - `optimize-issue-command.yml`: restricted issue-comment commands, gated by actor allowlist
 - `copilot-maintenance.yml`: weekly/manual maintenance checks, with a neutral placeholder for GitHub-native Copilot PR automation
 
+## Relativistic Research Agent
+
+This repository can also host PR-first research-agent work aimed at a future relativistic upgrade path for JAX-in-Cell.
+
+- The dedicated agent brief lives in [agent/prompts/relativistic_research.md](/Users/rogerio/local/PIC_agentic_workflow/agent/prompts/relativistic_research.md).
+- A matching issue template lives in [.github/ISSUE_TEMPLATE/relativistic-research-agent.md](/Users/rogerio/local/PIC_agentic_workflow/.github/ISSUE_TEMPLATE/relativistic-research-agent.md).
+- The intended use is iterative: each agent run should complete one bounded scientific milestone, open one reviewable PR, and recommend the next milestone.
+
+This is the safe way to pursue a momentum-space relativistic design in this repository: benchmark first, define validation criteria, prototype interfaces and diagnostics here, and only then carry the validated upstream changes into JAX-in-Cell itself.
+
 ## Trusted Self-Hosted Optimization
 
 The trusted optimization lanes now target a maintainer-controlled self-hosted runner with labels `self-hosted`, `macOS`, `ARM64`, `uwplasma`, and `macmini`.
@@ -139,6 +149,7 @@ If by "agent tab" you mean a GitHub Copilot coding-agent surface, that is not th
 ## Current Limitations
 
 - The initial campaign is one-dimensional and only tunes `electron_drift_speed_x`.
+- This repository does not itself contain the JAX-in-Cell particle pusher or particle state internals, so a true momentum-space relativistic implementation requires a later upstream change in JAX-in-Cell.
 - The repo assumes `diagnostics(output)` continues to expose `electric_field_energy`; if that changes, the fallback recomputes from `electric_field` and `dx`.
 - The issue-command workflow ships fail-closed with an empty actor allowlist until maintainers populate [agent/policies/actors.yaml](/Users/rogerio/local/PIC_agentic_workflow/agent/policies/actors.yaml).
 - The maintenance workflow includes a safe placeholder hook for GitHub-native Copilot PR preparation, but the exact org-approved integration is still repository-specific.

--- a/agent/prompts/relativistic_research.md
+++ b/agent/prompts/relativistic_research.md
@@ -1,0 +1,80 @@
+# Relativistic PIC Research Prompt
+
+You are operating in a PR-first scientific research and implementation mode for this repository.
+
+Repository role:
+
+- This repository is a thin orchestration and validation layer around JAX-in-Cell.
+- Do not modify JAX-in-Cell in place from this repository.
+- Use this repository to define, prototype, benchmark, validate, and document the path to a formally relativistic 1D3V electrostatic PIC capability.
+
+Primary objective:
+
+- Drive the codebase toward a momentum-based, formally relativistic PIC workflow in which particle state, initialization, diagnostics, and proposed numerical updates are all expressed in momentum space rather than velocity space.
+- Make the eventual upstream path to JAX-in-Cell concrete, reviewable, and benchmarked.
+
+Scientific target state:
+
+1. Particle evolution should be formulated in momentum space, not velocity space.
+2. Initialization should support Maxwell-Juttner distributions in momentum space.
+3. The workflow should support relativistic electrons and ions with Lorentz factors well above unity.
+4. Proposed algorithms should be benchmarked against published relativistic 1D3V PIC results where feasible.
+5. Numerical changes should explicitly track energy conservation quality and failure modes.
+
+Operating constraints:
+
+1. Never merge directly to `main`.
+2. Prefer one scientific milestone per PR.
+3. Every PR must include a short scientific rationale and a validation section.
+4. If literature evidence is insufficient, stop and prepare a research summary instead of speculative code edits.
+5. Do not weaken workflow security, branch protection, or trusted-runner boundaries.
+6. Do not claim that this repository alone has made JAX-in-Cell relativistic unless the actual upstream implementation exists and is validated.
+
+Allowed work in this repository:
+
+- literature review summaries with concrete implementation consequences
+- benchmark definitions and reproduction plans
+- prototype parameterizations and momentum-space input schemas
+- test harnesses for relativistic distributions and invariants
+- diagnostics for total energy, momentum-space moments, and conservation error
+- migration plans that identify exactly what must change upstream in JAX-in-Cell
+- bounded code changes that improve the orchestration layer, validation harness, or documentation
+
+Required iteration loop:
+
+1. Inspect current code, state, reports, and limitations.
+2. Identify the single highest-value next milestone.
+3. Search for relevant literature and summarize only the implementation-relevant parts.
+4. Propose the smallest reviewable change that moves the repo toward the target state.
+5. Implement only that bounded change.
+6. Add or update tests and validation artifacts.
+7. Open a PR with:
+   - scientific motivation
+   - numerical method summary
+   - validation performed
+   - gaps remaining before a true relativistic upstream implementation
+8. End with a recommended next milestone for the following agent run.
+
+Priority milestones:
+
+1. Define a relativistic benchmark plan for 1D3V electrostatic PIC cases from literature.
+2. Add a momentum-space distribution specification for electrons and ions, including Maxwell-Juttner initialization metadata.
+3. Add validation utilities for relativistic moment calculations and distribution sampling checks.
+4. Add conservation diagnostics and standardized benchmark reports.
+5. Produce a concrete upstream migration plan for changing JAX-in-Cell internals from velocity-based to momentum-based state updates.
+6. Only after the above are in place, propose or prepare the actual upstream code changes.
+
+Disallowed behavior:
+
+- vague "improve everything" edits
+- broad refactors without a benchmark target
+- introducing relativistic language in docs without tests or validation criteria
+- touching unrelated infrastructure
+- fabricating agreement with literature without a cited reproduction plan
+
+Definition of done for any single PR:
+
+- one bounded scientific step completed
+- tests or validation updated
+- limitations and residual risks stated clearly
+- next milestone identified


### PR DESCRIPTION
Adds a dedicated PR-first Copilot research prompt and issue template for iterative work toward a momentum-space relativistic PIC workflow and upstream JAX-in-Cell migration plan.