### PR TITLE
Add automated relativistic agent issue loop

### DIFF
--- a/.github/workflows/relativistic-agent-loop.yml
+++ b/.github/workflows/relativistic-agent-loop.yml
@@ -1,0 +1,32 @@
+name: Relativistic Agent Loop
+
+on:
+  schedule:
+    - cron: "43 * * * *"
+  issues:
+    types:
+      - closed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: relativistic-agent-loop
+  cancel-in-progress: true
+
+jobs:
+  ensure-loop-issue:
+    if: github.repository == 'uwplasma/PIC_AGENTIC_WORKFLOW'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Ensure open relativistic milestone issue exists
+        env:
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ensure_relativistic_issue_loop.py

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The optimizer state is stored as JSON observations rather than a Python pickle. 
 - `optimize-scheduled.yml`: hourly bounded optimization with concurrency control on the self-hosted runner
 - `optimize-issue-command.yml`: restricted issue-comment commands, gated by actor allowlist
 - `copilot-maintenance.yml`: weekly/manual maintenance checks, with a neutral placeholder for GitHub-native Copilot PR automation
+- `relativistic-agent-loop.yml`: hourly GitHub-hosted watchdog that ensures exactly one open Copilot-assigned relativistic milestone issue exists for the PR-first research loop
 
 ## Relativistic Research Agent
 
@@ -120,9 +121,13 @@ This repository can also host PR-first research-agent work aimed at a future rel
 
 - The dedicated agent brief lives in [agent/prompts/relativistic_research.md](/Users/rogerio/local/PIC_agentic_workflow/agent/prompts/relativistic_research.md).
 - A matching issue template lives in [.github/ISSUE_TEMPLATE/relativistic-research-agent.md](/Users/rogerio/local/PIC_agentic_workflow/.github/ISSUE_TEMPLATE/relativistic-research-agent.md).
+- The loop policy lives in [agent/policies/relativistic_loop.toml](/Users/rogerio/local/PIC_agentic_workflow/agent/policies/relativistic_loop.toml).
+- The watchdog automation lives in [.github/workflows/relativistic-agent-loop.yml](/Users/rogerio/local/PIC_agentic_workflow/.github/workflows/relativistic-agent-loop.yml).
 - The intended use is iterative: each agent run should complete one bounded scientific milestone, open one reviewable PR, and recommend the next milestone.
 
 This is the safe way to pursue a momentum-space relativistic design in this repository: benchmark first, define validation criteria, prototype interfaces and diagnostics here, and only then carry the validated upstream changes into JAX-in-Cell itself.
+
+The loop is now partially self-maintaining inside GitHub: when there is no open relativistic milestone issue, the watchdog workflow creates one and assigns it to `Copilot` plus the configured maintainers. The remaining platform dependency is GitHub Copilot itself: once the issue exists in the agent surface, GitHub decides when and how the coding agent executes. The repository can keep the queue populated automatically, but it cannot force the closed-source Copilot service to run continuously outside GitHub's own agent model.
 
 ## Trusted Self-Hosted Optimization
 

--- a/agent/policies/relativistic_loop.toml
+++ b/agent/policies/relativistic_loop.toml
@@ -1,0 +1,8 @@
+issue_label = "relativistic-agent"
+issue_label_color = "1d76db"
+issue_label_description = "Automated Copilot milestone loop for relativistic PIC work"
+
+issue_title = "Relativistic milestone: choose next highest-value bounded step"
+issue_title_prefix = "Relativistic milestone:"
+copilot_assignee = "Copilot"
+human_assignees = ["rogeriojorge"]

--- a/scripts/ensure_relativistic_issue_loop.py
+++ b/scripts/ensure_relativistic_issue_loop.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LoopConfig:
+    issue_label: str
+    issue_label_color: str
+    issue_label_description: str
+    issue_title: str
+    issue_title_prefix: str
+    copilot_assignee: str
+    human_assignees: list[str]
+
+
+def load_config(config_path: Path) -> LoopConfig:
+    raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    return LoopConfig(
+        issue_label=raw["issue_label"],
+        issue_label_color=raw["issue_label_color"],
+        issue_label_description=raw["issue_label_description"],
+        issue_title=raw["issue_title"],
+        issue_title_prefix=raw["issue_title_prefix"],
+        copilot_assignee=raw["copilot_assignee"],
+        human_assignees=list(raw.get("human_assignees", [])),
+    )
+
+
+def github_request(method: str, url: str, token: str, payload: dict[str, Any] | None = None) -> Any:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("User-Agent", "pic-agentic-workflow-relativistic-loop")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+
+    with urllib.request.urlopen(request) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return None
+        return json.loads(text)
+
+
+def github_request_optional(method: str, url: str, token: str, payload: dict[str, Any] | None = None) -> tuple[int, Any]:
+    try:
+        return 200, github_request(method, url, token, payload)
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8")
+        parsed = json.loads(body) if body else None
+        return error.code, parsed
+
+
+def build_issue_body(config: LoopConfig) -> str:
+    return f"""This issue was created automatically by the relativistic agent loop.
+
+Use [agent/prompts/relativistic_research.md](agent/prompts/relativistic_research.md) as the governing brief.
+
+Objective:
+- Keep advancing this repository toward a momentum-space, formally relativistic 1D3V electrostatic PIC workflow staging path for later upstream use in JAX-in-Cell.
+
+Execution requirements:
+1. Inspect the current repository state, latest reports, and any recent merged PRs.
+2. Select the single highest-value next bounded milestone.
+3. Ground the milestone in relevant scientific literature where needed.
+4. Make only the smallest reviewable change required for that milestone.
+5. Add validation, diagnostics, tests, or a bounded research summary.
+6. Open a PR against `main`.
+7. End the PR body with a section named `Next recommended milestone`.
+
+Guardrails:
+- Work only in this repository.
+- Do not modify JAX-in-Cell directly here.
+- Do not weaken workflow security, runner restrictions, or branch protection.
+- Do not claim full relativistic capability unless it is actually implemented and validated upstream.
+
+Loop behavior:
+- When this issue is completed and closed, the automation will create the next milestone issue.
+- Keep the scope to one milestone only.
+
+Expected labels and assignees:
+- label: `{config.issue_label}`
+- assignees: `{config.copilot_assignee}` and maintainers listed in `agent/policies/relativistic_loop.toml`
+"""
+
+
+def ensure_label(api_root: str, repo: str, token: str, config: LoopConfig) -> None:
+    label_url = (
+        f"{api_root}/repos/{repo}/labels/"
+        f"{urllib.parse.quote(config.issue_label, safe='')}"
+    )
+    status_code, _ = github_request_optional("GET", label_url, token)
+    if status_code == 200:
+        return
+    if status_code != 404:
+        raise RuntimeError(f"Unexpected label lookup status: {status_code}")
+
+    create_url = f"{api_root}/repos/{repo}/labels"
+    github_request(
+        "POST",
+        create_url,
+        token,
+        {
+            "name": config.issue_label,
+            "color": config.issue_label_color,
+            "description": config.issue_label_description,
+        },
+    )
+
+
+def list_open_loop_issues(api_root: str, repo: str, token: str, config: LoopConfig) -> list[dict[str, Any]]:
+    issues_url = (
+        f"{api_root}/repos/{repo}/issues?state=open&labels="
+        f"{urllib.parse.quote(config.issue_label, safe='')}&per_page=100"
+    )
+    issues = github_request("GET", issues_url, token)
+    return [
+        issue
+        for issue in issues
+        if "pull_request" not in issue and issue["title"].startswith(config.issue_title_prefix)
+    ]
+
+
+def ensure_issue_assignees(api_root: str, repo: str, token: str, issue_number: int, assignees: list[str]) -> None:
+    if not assignees:
+        return
+
+    assignee_url = f"{api_root}/repos/{repo}/issues/{issue_number}/assignees"
+    for assignee in assignees:
+        status_code, payload = github_request_optional(
+            "POST",
+            assignee_url,
+            token,
+            {"assignees": [assignee]},
+        )
+        if status_code == 200:
+            continue
+        message = ""
+        if isinstance(payload, dict):
+            message = payload.get("message", "")
+        print(f"Warning: could not assign '{assignee}' to issue #{issue_number}: {message}")
+
+
+def create_issue(api_root: str, repo: str, token: str, config: LoopConfig) -> dict[str, Any]:
+    create_url = f"{api_root}/repos/{repo}/issues"
+    issue = github_request(
+        "POST",
+        create_url,
+        token,
+        {
+            "title": config.issue_title,
+            "body": build_issue_body(config),
+            "labels": [config.issue_label],
+        },
+    )
+    issue_number = int(issue["number"])
+    ensure_issue_assignees(
+        api_root,
+        repo,
+        token,
+        issue_number,
+        [config.copilot_assignee, *config.human_assignees],
+    )
+    return issue
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ensure the relativistic Copilot milestone loop has an open issue.")
+    parser.add_argument("--dry-run", action="store_true", help="Render the issue body and planned action without calling GitHub.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(Path("agent/policies/relativistic_loop.toml"))
+
+    if args.dry_run:
+        print(config.issue_title)
+        print()
+        print(build_issue_body(config))
+        return 0
+
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    api_root = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+
+    if not token:
+        print("Missing GITHUB_TOKEN", file=sys.stderr)
+        return 1
+    if not repo:
+        print("Missing GITHUB_REPOSITORY", file=sys.stderr)
+        return 1
+
+    ensure_label(api_root, repo, token, config)
+    open_issues = list_open_loop_issues(api_root, repo, token, config)
+
+    if open_issues:
+        chosen_issue = sorted(open_issues, key=lambda issue: issue["number"])[0]
+        issue_number = int(chosen_issue["number"])
+        print(f"Found existing loop issue #{issue_number}: {chosen_issue['title']}")
+        ensure_issue_assignees(
+            api_root,
+            repo,
+            token,
+            issue_number,
+            [config.copilot_assignee, *config.human_assignees],
+        )
+        return 0
+
+    issue = create_issue(api_root, repo, token, config)
+    print(f"Created new loop issue #{issue['number']}: {issue['title']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a GitHub-hosted watchdog workflow plus a standard-library Python script that ensures the repository always has one open Copilot-assigned relativistic milestone issue. This makes the PR-first research loop self-maintaining inside GitHub while preserving existing security boundaries.